### PR TITLE
Link "last updated" footer to the GitHub repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filter pulse (drop-shadow + brightness + contrast) that holds at peak
   for a third of the cycle. The base image stays static, so only the
   "SIGNS POINT TO YES" / "OUTLOOK NOT SO GOOD" / etc. region shimmers.
+- Footer "last updated …" timestamp now links to the GitHub repo
+  (`https://github.com/welch/sportsball`). Anchor opens in a new tab
+  (`target="_blank"` + `rel="noopener noreferrer"`) and inherits the
+  footer's grey color with no underline across all link states, so the
+  footer looks identical to before — just clickable.
 
 ## [0.3.0] - 2026-05-05
 

--- a/src/sportsball/static/css/8ball.css
+++ b/src/sportsball/static/css/8ball.css
@@ -209,6 +209,14 @@ footer {
     text-align: center;
 }
 
+footer a,
+footer a:hover,
+footer a:visited,
+footer a:active {
+    color: inherit;
+    text-decoration: none;
+}
+
 @media (max-width: 480px) {
     body {
         width: 95%;

--- a/src/sportsball/templates/8ball.html
+++ b/src/sportsball/templates/8ball.html
@@ -59,7 +59,7 @@
       {% endif %}
     </main>
     {% if last_updated %}
-      <footer>last updated {{ last_updated }}</footer>
+      <footer><a href="https://github.com/welch/sportsball" target="_blank" rel="noopener noreferrer">last updated {{ last_updated }}</a></footer>
     {% endif %}
   </body>
 </html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -201,6 +201,40 @@ def test_index_shows_last_updated_footer(
     main._cache["fetched_at"] = 0.0
 
 
+def test_index_footer_links_to_github_repo(
+    monkeypatch: pytest.MonkeyPatch, fixed_now: datetime
+) -> None:
+    import time as _time
+
+    main._cache["events"] = []
+    main._cache["fetched_at"] = _time.time()
+    monkeypatch.setattr(main, "_events", lambda: [])
+    response = main.app.test_client().get("/")
+    body = response.data
+    # Anchor wrapping the footer text, opening in a new tab with safe rel.
+    assert b'href="https://github.com/welch/sportsball"' in body
+    assert b'target="_blank"' in body
+    assert b'rel="noopener noreferrer"' in body
+    # The anchor wraps the existing footer text, not a separate node.
+    assert b'sportsball" target="_blank" rel="noopener noreferrer">last updated ' in body
+    main._cache["events"] = None
+    main._cache["fetched_at"] = 0.0
+
+
+def test_footer_link_inherits_styling_in_served_css() -> None:
+    response = main.app.test_client().get("/static/css/8ball.css")
+    assert response.status_code == 200
+    css = response.data.decode()
+    # Anchor must inherit color and drop underline across all link states so
+    # the footer looks identical whether visited or not.
+    assert "footer a" in css
+    assert "footer a:hover" in css
+    assert "footer a:visited" in css
+    assert "footer a:active" in css
+    assert "color: inherit" in css
+    assert "text-decoration: none" in css
+
+
 def test_refresh_requires_cron_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(main, "_events", lambda: [])
     response = main.app.test_client().get("/tasks/refresh")


### PR DESCRIPTION
## Summary

- Wraps the small grey "last updated …" footer text in an `<a>` to `https://github.com/welch/sportsball` (opens in a new tab via `target="_blank" rel="noopener noreferrer"`).
- Forces `color: inherit; text-decoration: none` on every link state (default, `:hover`, `:visited`, `:active`) so the footer's appearance is unchanged — just clickable.

## Test plan
- [x] Existing tests pass (56 total)
- [x] New: `test_index_footer_links_to_github_repo` — anchor + href + target + rel asserted in rendered HTML
- [x] New: `test_footer_link_inherits_styling_in_served_css` — served CSS contains all four link states with the inherit rules
- [x] Manual: hover the footer, confirm no underline appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)