### PR TITLE
Redirect non-canonical hosts via CANONICAL_HOST env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   named adapter tuples and records success/failure per source. The health
   endpoint itself is excluded from the request counter so reloading it
   doesn't pollute the numbers.
+- 301-redirect non-canonical hosts to the host configured via the
+  `CANONICAL_HOST` env var. `before_request` hook reads the canonical
+  bare hostname from `os.environ` and redirects to
+  `https://$CANONICAL_HOST<path>?<query>` whenever `request.host`
+  differs. No-ops when the env var is unset (local dev). `/healthz` and
+  requests with `X-Appengine-Cron: true` are exempt so GAE health checks
+  and cron continue to work on the appspot host. Busts stale 301s
+  cached by browsers from the previous reverse-direction redirect.
 - Pulsing-glow effect on the 8-ball's answer window. A duplicate of the
   ball image is layered over the base, clipped to a circle around the
   answer window (`circle(23% at 50% 47%)`), and animated with a 3-second

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Format:
 env_variables:
   TICKETMASTER_API_KEY: <your-key>
   VERB: <default-verb-shown-in-page-title>
+  CANONICAL_HOST: <your-canonical-host>
   # add more as needed
 ```
 
@@ -57,6 +58,13 @@ Variables:
   invisible to scanners. The page shows per-adapter status, the rolling
   24-hour HTTP request counts, and event-cache age — load it in a
   browser when you want a quick read on the deploy.
+- `CANONICAL_HOST` — optional. Bare hostname (no scheme, no path,
+  e.g. `example.com`) to canonicalize on. When set, any request whose
+  `Host` header doesn't match is 301-redirected to
+  `https://$CANONICAL_HOST<path>?<query>`. `/healthz` and requests
+  carrying `X-Appengine-Cron: true` are exempt so GAE health checks and
+  cron keep working on the appspot host. Leave unset locally so dev
+  requests on `localhost` aren't redirected.
 
 ## Deploy
 

--- a/src/sportsball/main.py
+++ b/src/sportsball/main.py
@@ -8,9 +8,10 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from flask import Flask, abort, render_template, request, url_for
+from flask import Flask, abort, redirect, render_template, request, url_for
 from markupsafe import Markup, escape
 from werkzeug.routing import BaseConverter, ValidationError
+from werkzeug.wrappers import Response
 
 from sportsball import stats
 from sportsball.adapters import giants, ticketmaster, warriors
@@ -56,6 +57,23 @@ class VerbConverter(BaseConverter):
 app = Flask(__name__)
 app.url_map.converters["isodate"] = IsoDateConverter
 app.url_map.converters["verb"] = VerbConverter
+
+
+@app.before_request
+def _redirect_to_canonical_host() -> Response | None:
+    """301-redirect non-canonical hosts to `CANONICAL_HOST`.
+
+    No-ops when `CANONICAL_HOST` is unset (local dev). Skips `/healthz` and
+    GAE cron requests so they keep working on the appspot host.
+    """
+    canonical = os.environ.get("CANONICAL_HOST")
+    if not canonical or request.host == canonical:
+        return None
+    if request.path == "/healthz":
+        return None
+    if request.headers.get("X-Appengine-Cron") == "true":
+        return None
+    return redirect(f"https://{canonical}{request.full_path}", code=301)
 
 
 def _compute_static_hash() -> str:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -411,6 +411,64 @@ def test_index_mixed_sports_and_concert_neutral_verb(
     assert b'class="verb concert"' not in response.data
 
 
+def test_canonical_host_no_redirect_when_host_matches(
+    monkeypatch: pytest.MonkeyPatch, fixed_now: datetime
+) -> None:
+    monkeypatch.setenv("CANONICAL_HOST", "example.com")
+    monkeypatch.setattr(main, "_events", lambda: [])
+    response = main.app.test_client().get("/", headers={"Host": "example.com"})
+    assert response.status_code == 200
+
+
+def test_canonical_host_redirects_non_canonical_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CANONICAL_HOST", "example.com")
+    response = main.app.test_client().get("/", headers={"Host": "sports-ball.appspot.com"})
+    assert response.status_code == 301
+    # Werkzeug normalizes a bare trailing "?" off the Location URL.
+    assert response.headers["Location"].rstrip("?") == "https://example.com/"
+
+
+def test_canonical_host_redirect_preserves_query_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CANONICAL_HOST", "example.com")
+    response = main.app.test_client().get(
+        "/some/path?foo=bar", headers={"Host": "sports-ball.appspot.com"}
+    )
+    assert response.status_code == 301
+    assert response.headers["Location"].endswith("?foo=bar")
+    assert response.headers["Location"] == "https://example.com/some/path?foo=bar"
+
+
+def test_canonical_host_does_not_redirect_healthz(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CANONICAL_HOST", "example.com")
+    response = main.app.test_client().get("/healthz", headers={"Host": "sports-ball.appspot.com"})
+    assert response.status_code == 200
+    assert response.data == b"ok"
+
+
+def test_canonical_host_does_not_redirect_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CANONICAL_HOST", "example.com")
+    monkeypatch.setattr(main, "_events", lambda: [])
+    response = main.app.test_client().get(
+        "/tasks/refresh",
+        headers={"Host": "sports-ball.appspot.com", "X-Appengine-Cron": "true"},
+    )
+    assert response.status_code == 200
+    # Reset cache state for downstream tests.
+    main._cache["events"] = None
+    main._cache["fetched_at"] = 0.0
+
+
+def test_canonical_host_unset_never_redirects(
+    monkeypatch: pytest.MonkeyPatch, fixed_now: datetime
+) -> None:
+    monkeypatch.delenv("CANONICAL_HOST", raising=False)
+    monkeypatch.setattr(main, "_events", lambda: [])
+    response = main.app.test_client().get("/", headers={"Host": "localhost:5000"})
+    assert response.status_code == 200
+
+
 def test_index_warriors_colorized_and_blue_verb(
     monkeypatch: pytest.MonkeyPatch, fixed_now: datetime
 ) -> None:


### PR DESCRIPTION
## Summary

- New Flask `before_request` hook that 301-redirects any non-canonical host to `https://$CANONICAL_HOST<path>?<query>` (preserves query string).
- Configured via `CANONICAL_HOST` env var; **the actual domain stays out of git** (set in gitignored `env.yaml`, same convention as `VERB`).
- Skips `/healthz` and `X-Appengine-Cron: true` requests so GAE health checks and cron continue to work on the appspot host.
- No-op when `CANONICAL_HOST` is unset (local dev).

## Why

- Browsers cached a 301 from the custom domain → `appspot.com/<path>/` from the previous setup. Redirecting `appspot.com → custom domain` "breaks through" that cache (one extra hop, then canonical).
- Canonicalizes the address bar — users see the custom domain regardless of which host they land on.

## Test plan
- [x] 60 tests pass; 6 new in `tests/test_main.py` cover host match, redirect, query-string preservation, healthz exemption, cron exemption, unset-env behavior. Tests use `example.com` as the placeholder.
- [x] `grep -ri ismydayfucked` returns zero hits in tracked files.
- [ ] Manual: deploy, hit `https://sports-ball.appspot.com/` → expect 301 to canonical
- [ ] Manual: hit `https://sports-ball.appspot.com/healthz` → expect 200, no redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)